### PR TITLE
Manually Open Wallet Universal Links

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -8,15 +8,9 @@ interface DeepLinkReplacement {
   appScheme: string;
 }
 
-const deepLinkReplacements: DeepLinkReplacement[] = [
-  // {
-  //   httpsHostAndProtocol: 'https://metamask.app.link/',
-  //   appScheme: 'metamask://',
-  // },
-  // {
-  //   httpsHostAndProtocol: 'https://rnbwapp.com/',
-  //   appScheme: 'rainbow://',
-  // },
+const walletDeepLinkHosts = [
+  'https://metamask.app.link',
+  'https://rnbwapp.com',
 ];
 
 const App: FC = () => {
@@ -28,22 +22,11 @@ const App: FC = () => {
           uri: 'https://funny-bombolone-7101cc.netlify.app/',
         }}
         onShouldStartLoadWithRequest={(event) => {
-          console.log(event);
-          const deepLinkReplacement = deepLinkReplacements.find(
-            ({ httpsHostAndProtocol }) =>
-              event.url.startsWith(httpsHostAndProtocol),
-          );
-
-          if (deepLinkReplacement) {
-            const targetUrl = decodeURIComponent(
-              event.url.replace(
-                deepLinkReplacement.httpsHostAndProtocol,
-                deepLinkReplacement.appScheme,
-              ),
-            );
-            console.log(`\nattempting to open ${targetUrl}\n`);
-            Linking.openURL(targetUrl);
-            return false;
+          for (const walletDeepLinkHost of walletDeepLinkHosts) {
+            if (event.url.startsWith(walletDeepLinkHost)) {
+              Linking.openURL(event.url);
+              return false;
+            }
           }
 
           return true;

--- a/App.tsx
+++ b/App.tsx
@@ -9,10 +9,10 @@ interface DeepLinkReplacement {
 }
 
 const deepLinkReplacements: DeepLinkReplacement[] = [
-  {
-    httpsHostAndProtocol: 'https://metamask.app.link/',
-    appScheme: 'metamask://',
-  },
+  // {
+  //   httpsHostAndProtocol: 'https://metamask.app.link/',
+  //   appScheme: 'metamask://',
+  // },
   // {
   //   httpsHostAndProtocol: 'https://rnbwapp.com/',
   //   appScheme: 'rainbow://',

--- a/App.tsx
+++ b/App.tsx
@@ -1,7 +1,23 @@
 import React, { FC } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, View } from 'react-native';
+import { Linking, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
+
+interface DeepLinkReplacement {
+  httpsHostAndProtocol: string;
+  appScheme: string;
+}
+
+const deepLinkReplacements: DeepLinkReplacement[] = [
+  {
+    httpsHostAndProtocol: 'https://metamask.app.link/',
+    appScheme: 'metamask://',
+  },
+  // {
+  //   httpsHostAndProtocol: 'https://rnbwapp.com/',
+  //   appScheme: 'rainbow://',
+  // },
+];
 
 const App: FC = () => {
   return (
@@ -10,6 +26,27 @@ const App: FC = () => {
       <WebView
         source={{
           uri: 'https://funny-bombolone-7101cc.netlify.app/',
+        }}
+        onShouldStartLoadWithRequest={(event) => {
+          console.log(event);
+          const deepLinkReplacement = deepLinkReplacements.find(
+            ({ httpsHostAndProtocol }) =>
+              event.url.startsWith(httpsHostAndProtocol),
+          );
+
+          if (deepLinkReplacement) {
+            const targetUrl = decodeURIComponent(
+              event.url.replace(
+                deepLinkReplacement.httpsHostAndProtocol,
+                deepLinkReplacement.appScheme,
+              ),
+            );
+            console.log(`\nattempting to open ${targetUrl}\n`);
+            Linking.openURL(targetUrl);
+            return false;
+          }
+
+          return true;
         }}
       />
     </View>

--- a/App.tsx
+++ b/App.tsx
@@ -3,12 +3,7 @@ import { StatusBar } from 'expo-status-bar';
 import { Linking, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
-interface DeepLinkReplacement {
-  httpsHostAndProtocol: string;
-  appScheme: string;
-}
-
-const walletDeepLinkHosts = [
+const walletUniversalLinkHosts = [
   'https://metamask.app.link',
   'https://rnbwapp.com',
 ];
@@ -22,8 +17,8 @@ const App: FC = () => {
           uri: 'https://funny-bombolone-7101cc.netlify.app/',
         }}
         onShouldStartLoadWithRequest={(event) => {
-          for (const walletDeepLinkHost of walletDeepLinkHosts) {
-            if (event.url.startsWith(walletDeepLinkHost)) {
+          for (const walletUniversalLinkHost of walletUniversalLinkHosts) {
+            if (event.url.startsWith(walletUniversalLinkHost)) {
               Linking.openURL(event.url);
               return false;
             }

--- a/app.json
+++ b/app.json
@@ -14,12 +14,13 @@
     "updates": {
       "fallbackToCacheTimeout": 0
     },
-    "assetBundlePatterns": [
-      "**/*"
-    ],
+    "assetBundlePatterns": ["**/*"],
     "ios": {
       "supportsTablet": true,
-      "bundleIdentifier": "com.farcaster.wagmitestandroid"
+      "bundleIdentifier": "com.farcaster.wagmitestandroid",
+      "infoPlist": {
+        "LSApplicationQueriesSchemes": ["rainbow", "metamask"]
+      }
     },
     "android": {
       "adaptiveIcon": {


### PR DESCRIPTION
This PR demonstrates that if we intercept deep/universal links to wallets, then manually launch them with [`Linking.openURL`](https://reactnative.dev/docs/linking#openurl), we can successfully connect to and sign messages from both Rainbow and Metamask.

There is, however, a bug where if you open a deep/universal link to one of the wallets (it doesn't matter which one), then try to connect to another wallet within the same session, the first wallet app will launch. Reloading the app will allow each of the deep/universal links to work again. In some other PRs, I'll try to figure out where this failure is happening:
- https://github.com/nickcherry/rainbowkit-test-mobile-2/pull/2
- https://github.com/nickcherry/rainbowkit-test-mobile-2/pull/3 
- https://github.com/nickcherry/rainbowkit-test-mobile-2/pull/4

**Latest Hypothesis:** It seems that when using anchor tags (i.e. `<a href="">`) for deep/universal links, we can successfully launch wallets. Perhaps the issues we've been experiencing are related to RainbowKit using a different strategy (e.g. manually setting window url with javascript) to open deep/universal links. **Update** Indeed, https://github.com/nickcherry/rainbowkit-test-mobile-2/pull/4 seems to confirm that launch wallets via `window.location.href = url;` works while `window.open(url, '_blank', 'noreferrer,noopener');` does not. I'm not sure why there is a conditional [here](https://github.com/rainbow-me/rainbowkit/pull/479/files#r907599654), but I think we need to update RainbowKit to prefer `window.location.href = url;` in more cases, if not for all cases.