### PR TITLE
Open Normal Links Without Rainbowkit

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { Button, Linking, StyleSheet, View } from 'react-native';
+import { Linking, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 const App: FC = () => {

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, View } from 'react-native';
+import { Button, Linking, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 const App: FC = () => {
@@ -8,8 +8,35 @@ const App: FC = () => {
     <View style={styles.container}>
       <StatusBar style="auto" />
       <WebView
+        onShouldStartLoadWithRequest={(event) => {
+          if (event.url === 'about:blank') {
+            return true;
+          }
+
+          Linking.openURL(event.url);
+          return false;
+        }}
         source={{
-          uri: 'https://funny-bombolone-7101cc.netlify.app/',
+          html: `
+            <html>
+              <body>
+                <style>
+                  body {
+                    align-items: center;
+                    display: flex;
+                    flex-direction: column;
+                    font-size: 64px;
+                    justify-content: center;
+                  }
+                  a {
+                    margin-bottom: 3rem;
+                  }
+                </style>
+                <a href="https://rnbwapp.com/wc">Open Rainbow</a>
+                <a href="https://metamask.app.link">Open Metamask</a>
+                <a href="https://google.com">Open Google</a>
+              </body>
+            </html>`,
         }}
       />
     </View>

--- a/App.tsx
+++ b/App.tsx
@@ -8,14 +8,6 @@ const App: FC = () => {
     <View style={styles.container}>
       <StatusBar style="auto" />
       <WebView
-        onShouldStartLoadWithRequest={(event) => {
-          if (event.url === 'about:blank') {
-            return true;
-          }
-
-          Linking.openURL(event.url);
-          return false;
-        }}
         source={{
           html: `
             <html>

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { Linking, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 const App: FC = () => {


### PR DESCRIPTION
Follow-up to https://github.com/nickcherry/rainbowkit-test-mobile-2/pull/1, where render basic links and let the webview handle them naturally, without intercepting requests or using [`Linking.openURL`](https://reactnative.dev/docs/linking#openurl).

**Observation:** Deep/universal links and regular links work fine, and we don't see the caching problem that we previously saw with RainbowKit.