### PR TITLE
Launch Links With Javascript

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
-import React, { FC, useEffect } from 'react';
+import React, { FC } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { Button, Linking, StyleSheet, View } from 'react-native';
+import { Linking, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 const App: FC = () => {

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { StyleSheet, View } from 'react-native';
+import { Button, Linking, StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 const App: FC = () => {
@@ -8,8 +8,35 @@ const App: FC = () => {
     <View style={styles.container}>
       <StatusBar style="auto" />
       <WebView
+        onShouldStartLoadWithRequest={(event) => {
+          if (event.url === 'about:blank') {
+            return true;
+          }
+
+          Linking.openURL(event.url);
+          return false;
+        }}
         source={{
-          uri: 'https://funny-bombolone-7101cc.netlify.app/',
+          html: `
+            <html>
+              <body>
+                <style>
+                  body {
+                    align-items: center;
+                    display: flex;
+                    flex-direction: column;
+                    font-size: 64px;
+                    justify-content: center;
+                  }
+                  a {
+                    margin-bottom: 3rem;
+                  }
+                </style>
+                <a href="https://rnbwapp.com/wc">Open Rainbow</a>
+                <a href="https://metamask.app.link">Open Metamask</a>
+                <a href="https://google.com">Open Google</a>
+              </body>
+            </html>`,
         }}
       />
     </View>

--- a/App.tsx
+++ b/App.tsx
@@ -8,14 +8,6 @@ const App: FC = () => {
     <View style={styles.container}>
       <StatusBar style="auto" />
       <WebView
-        onShouldStartLoadWithRequest={(event) => {
-          if (event.url === 'about:blank') {
-            return true;
-          }
-
-          Linking.openURL(event.url);
-          return false;
-        }}
         source={{
           html: `
             <html>

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { StatusBar } from 'expo-status-bar';
-import { Linking, StyleSheet, View } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { WebView } from 'react-native-webview';
 
 const App: FC = () => {

--- a/App.tsx
+++ b/App.tsx
@@ -24,9 +24,24 @@ const App: FC = () => {
                     margin-bottom: 3rem;
                   }
                 </style>
-                <a href="https://rnbwapp.com/wc">Open Rainbow</a>
-                <a href="https://metamask.app.link">Open Metamask</a>
-                <a href="https://google.com">Open Google</a>
+                <a data-href="https://rnbwapp.com/wc">Open Rainbow</a>
+                <a data-href="https://metamask.app.link">Open Metamask</a>
+                <a data-href="https://google.com">Open Google</a>
+                <script>
+                  document.addEventListener('DOMContentLoaded', () => {
+                    document.querySelectorAll('a').forEach((link) => {
+                      link.addEventListener('click', (e) => {
+                        const url = e.target.dataset.href;
+
+                        // This works
+                        window.location.href = url;
+
+                        // This does not work
+                        // window.open(url, '_blank', 'noreferrer,noopener');
+                      })
+                    })
+                  });
+                </script>
               </body>
             </html>`,
         }}


### PR DESCRIPTION
Follow-up to https://github.com/nickcherry/rainbowkit-test-mobile-2/pull/1, where we imperatively launch wallets with javascript – as opposed to intercepting requests at the React Native level or letting mobile Safari naturally handle anchor tag links. 

**Observation:** When try to launch wallets with `window.location.href = url;`, the links work. When we try to launch wallets with `window.open(url, '_blank', 'noreferrer,noopener');`, it doesn't work. I think [this](https://github.com/rainbow-me/rainbowkit/blob/1ab9c07e4326d8ea8841507edf7f5c2f8ea38af6/packages/rainbowkit/src/components/ConnectOptions/MobileOptions.tsx#L60-L64) may be where the problem lies.